### PR TITLE
music bugs & cactus short 01

### DIFF
--- a/FlyingWhalesGame/Assets/Environment/CactusPack/Prefabs/Cactus_Short_01.prefab
+++ b/FlyingWhalesGame/Assets/Environment/CactusPack/Prefabs/Cactus_Short_01.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 2300000}
   - component: {fileID: 6400000}
   - component: {fileID: 1951267004}
-  - component: {fileID: 581565585}
+  - component: {fileID: 4155052583500689237}
   m_Layer: 0
   m_Name: Cactus_Short_01
   m_TagString: Untagged
@@ -110,8 +110,8 @@ MonoBehaviour:
   timeBetweenAttacks: 1.1
   KillOnTouch: 0
   DestroyAfterDamage: 0
---- !u!136 &581565585
-CapsuleCollider:
+--- !u!65 &4155052583500689237
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -120,7 +120,6 @@ CapsuleCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
-  m_Radius: 0.28461808
-  m_Height: 0.74304515
-  m_Direction: 1
-  m_Center: {x: -0.057660274, y: 0.37104356, z: -0.031580962}
+  serializedVersion: 2
+  m_Size: {x: 0.52087593, y: 0.7430449, z: 0.5412669}
+  m_Center: {x: -0.057386, y: 0.37104347, z: -0.03158002}

--- a/FlyingWhalesGame/Assets/Scenes/Level.unity
+++ b/FlyingWhalesGame/Assets/Scenes/Level.unity
@@ -2410,7 +2410,7 @@ Transform:
   m_LocalScale: {x: 0.85123307, y: 0.7866507, z: 0.5440047}
   m_Children: []
   m_Father: {fileID: 1143991583}
-  m_RootOrder: 12
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: -9.231001, y: 4.6600003, z: -7.564}
 --- !u!23 &282337790
 MeshRenderer:
@@ -4615,6 +4615,7 @@ GameObject:
   m_Component:
   - component: {fileID: 581369101}
   - component: {fileID: 581369100}
+  - component: {fileID: 581369102}
   m_Layer: 0
   m_Name: BGM
   m_TagString: BackgroundMusic
@@ -4733,6 +4734,19 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 17
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &581369102
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 581369099}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 882174b22ac8e6c498138edcc6d6547f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 0}
 --- !u!1001 &581565581
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4788,18 +4802,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 400000, guid: 3170071b601530b49b08f06beca71b57, type: 3}
-      propertyPath: m_LocalScale.x
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 400000, guid: 3170071b601530b49b08f06beca71b57, type: 3}
-      propertyPath: m_LocalScale.y
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 400000, guid: 3170071b601530b49b08f06beca71b57, type: 3}
-      propertyPath: m_LocalScale.z
-      value: 7
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3170071b601530b49b08f06beca71b57, type: 3}
 --- !u!4 &581565582 stripped
@@ -4808,41 +4810,6 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 581565581}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &581565583 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 100000, guid: 3170071b601530b49b08f06beca71b57,
-    type: 3}
-  m_PrefabInstance: {fileID: 581565581}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &581565584
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 581565583}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 765dc9ac7eff0e74c944fb0844024227, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  timeBetweenAttacks: 0.5
-  KillOnTouch: 0
-  DestroyAfterDamage: 0
---- !u!136 &581565585
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 581565583}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  m_Radius: 0.27063346
-  m_Height: 0.7430449
-  m_Direction: 1
-  m_Center: {x: -0.057386, y: 0.37104347, z: -0.031580973}
 --- !u!1 &588829112
 GameObject:
   m_ObjectHideFlags: 0
@@ -8960,13 +8927,13 @@ Transform:
   - {fileID: 35506885}
   - {fileID: 964298728}
   - {fileID: 744704424}
+  - {fileID: 282337789}
   - {fileID: 2080401960}
   - {fileID: 837552652}
   - {fileID: 1578333937}
   - {fileID: 2049701621}
   - {fileID: 335963954}
   - {fileID: 2114948013}
-  - {fileID: 282337789}
   - {fileID: 946850114}
   - {fileID: 1119332714}
   - {fileID: 76412289}
@@ -14768,7 +14735,8 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 581565584, guid: 3170071b601530b49b08f06beca71b57, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 3170071b601530b49b08f06beca71b57, type: 3}
 --- !u!4 &1951267002 stripped
 Transform:

--- a/FlyingWhalesGame/Assets/Scenes/OpenMap.unity
+++ b/FlyingWhalesGame/Assets/Scenes/OpenMap.unity
@@ -18266,6 +18266,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1139854960}
   - component: {fileID: 1139854959}
+  - component: {fileID: 1139854961}
   m_Layer: 0
   m_Name: BGM
   m_TagString: BackgroundMusic
@@ -18384,6 +18385,19 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 56
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1139854961
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1139854958}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 882174b22ac8e6c498138edcc6d6547f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  player: {fileID: 0}
 --- !u!1001 &1141980212
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/FlyingWhalesGame/Assets/Scripts/Generic/DontDestroy.cs
+++ b/FlyingWhalesGame/Assets/Scripts/Generic/DontDestroy.cs
@@ -1,9 +1,12 @@
 ﻿using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class DontDestroy : MonoBehaviour
 {
+    private AudioSource audioSource;
 	private void Awake()
 	{
+        audioSource = GetComponent<AudioSource>();
 		GameObject[] objs = GameObject.FindGameObjectsWithTag("BackgroundMusic");
 		if (objs.Length > 1)
 		{
@@ -18,4 +21,17 @@ public class DontDestroy : MonoBehaviour
 		}
 		DontDestroyOnLoad(this.gameObject);
 	}
+
+    // (by Sabin Kim) probably a very bashy/inefficient solution to make the intro cutscene music shut up
+    void Update()
+    {
+        if (SceneManager.GetActiveScene().name == "OpenMap")
+        {
+            while (audioSource.volume > 0)
+            {
+                audioSource.volume -= .04f;
+            }
+            Destroy(this);
+        }
+    }
 }

--- a/FlyingWhalesGame/Assets/Scripts/Generic/stopWhenDead.cs
+++ b/FlyingWhalesGame/Assets/Scripts/Generic/stopWhenDead.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class stopWhenDead : MonoBehaviour
+{
+    private AudioSource audio;
+    public GameObject player;
+    // Start is called before the first frame update
+    void Awake()
+    {
+        audio = GetComponent<AudioSource>();
+        audio.mute = false;
+        player = GameObject.FindGameObjectWithTag("Player");
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (player.GetComponent<PlayerHealth>().Health <= 0)
+        {
+            audio.mute = true;
+        }
+    }
+}


### PR DESCRIPTION
-changed DontDestroy.cs so that when the current scene is OpenMap, the intro cutscene music fades to volume 0
-added stopWhenDead.cs, which BGM objects in OpenMap and Level will have: these songs will be muted when Player health reaches 0; unmuted when Awake()
-changed collider of Cactus_Short_01 to box collider